### PR TITLE
Config via command line

### DIFF
--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -1,8 +1,9 @@
 const Discord=require('discord.js');
 const bot=new Discord.Client();
 const request = require('request');
-const config = require('./RDMMonitorConfig.json');
-
+const args = process.argv.splice(2);
+const configPath = args.length > 0 ? './' + args[0] : './RDMMonitorConfig.json'
+const config = require(configPath);
 
 const warningImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/warned.png";
 const okImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/ok.png";

--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -2,7 +2,7 @@ const Discord=require('discord.js');
 const bot=new Discord.Client();
 const request = require('request');
 const args = process.argv.splice(2);
-const configPath = args.length > 0 ? './' + args[0] : './RDMMonitorConfig.json'
+const configPath = args.length > 0 ? './' + args[0] : './RDMMonitorConfig.json';
 const config = require(configPath);
 
 const warningImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/warned.png";


### PR DESCRIPTION
Allows the config path to be passed via the command line arguments. Prevents having to clone the repository to multiple folders and just pass the config to use via command line. Provided config is assumed in the same folder.  

If no config path is specified the default `RDMMonitorConfig.json` is used.  

Example: `node RDMMonitor.js config.json`  